### PR TITLE
feat: add `tips add` command for manual tip creation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,93 @@
+# Architecture Review
+
+## Overview
+
+`trajectory-tips` is a file-backed CLI for extracting, storing, retrieving, and injecting agent-memory tips.
+The current structure is workable, but path resolution and dependency injection are inconsistent across the call graph, which leaks `process.cwd()` and environment state into tests and command behavior.
+
+## Dependency Graph
+
+- `bin/tips.js` -> `src/cli.js`
+- `src/cli.js` -> `src/extract.js`, `src/analyzer.js`, `src/contrastive.js`, `src/inject.js`, `src/retrieve.js`, `src/store.js`, `src/utils.js`
+- `src/extract.js` -> `src/embeddings.js`, `src/analyzer.js`, `src/utils.js`, `src/store.js`
+- `src/inject.js` -> `src/retrieve.js`, `src/utils.js`
+- `src/retrieve.js` -> `src/utils.js`, `src/embeddings.js`, `src/store.js`
+- `src/store.js` -> `src/utils.js`, `src/embeddings.js`
+- `src/seed.js` -> `src/utils.js`, `src/store.js`, `src/embeddings.js`
+- `src/analyzer.js` -> `src/embeddings.js`
+- `src/contrastive.js` -> `src/analyzer.js`, `src/embeddings.js`, `src/store.js`
+- `test/*.test.js` mostly target public module exports directly; `test/add.test.js` and `test/cli.test.js` go through `createProgram()`
+
+## Issue Inventory
+
+### 1. Path resolution is only partially dynamic
+
+- `src/utils.js`
+  - `DEFAULT_TIPS_DIR` is computed at module load from `process.env.TIPS_DIR` or `process.cwd()`.
+  - `DEFAULT_INDEX_PATH` is computed at module load from `process.cwd()`.
+  - `getTipsDir()` still falls back to `DEFAULT_TIPS_DIR`, so changing cwd after import keeps a stale tips directory.
+  - `getIndexPath()` is dynamic already, but the module still exports a stale `DEFAULT_INDEX_PATH`, so the path model is internally inconsistent.
+- `src/store.js`
+  - `saveTip()`, `loadIndex()`, `saveIndex()`, `consolidateTips()`, `reindexAllTips()`, and `recordFeedback()` default through `getTipsDir()` / `getIndexPath()`, so they inherit the stale `DEFAULT_TIPS_DIR` issue.
+- `src/retrieve.js`
+  - `queryTips()` defaults through `getTipsDir()` / `getIndexPath()`.
+- `src/cli.js`
+  - `addTipFromOptions()` resolves paths internally via `getTipsDir()` / `getIndexPath()` instead of accepting a shared context.
+  - `list`, `health`, and every command that omits explicit paths rely on ambient cwd/env.
+- `src/seed.js`
+  - `seedBaseTips()` defaults `tipsDir` via `getTipsDir()`.
+  - It bypasses helpers and hardcodes `path.resolve(process.cwd(), 'index.json')` for the index, which is another direct cwd dependency.
+
+### 2. Test isolation is brittle
+
+- `test/add.test.js`
+  - Uses `process.chdir()` and `process.env.TIPS_DIR` to steer CLI outputs.
+  - Imports `getIndexPath()` from `src/utils.js`, so assertions still depend on process-global state.
+- `test/store.test.js` and `test/retrieve.test.js`
+  - Already pass `tipsDir` / `indexPath` explicitly, which is the better pattern and should become standard.
+- Current fake embedders are inconsistent
+  - `test/store.test.js` still uses a 3-dimensional vector, which is too small and can collapse unrelated texts into high cosine similarity.
+  - `test/add.test.js` already uses a 16-dimensional hash-spread embedder; that approach should be shared.
+
+### 3. `createProgram()` DI stops at `add`
+
+- `src/cli.js`
+  - `createProgram()` accepts overrides for `addTip`, `embedder`, `promptForFields`, and `yaml`, but all other commands call hard imports directly.
+  - `extract`, `query`, `inject`, `consolidate`, `feedback`, `import`, `reindex`, `seed`, `contrast`, `list`, and `health` all read ambient state and use concrete module functions instead of injected dependencies.
+  - This makes command-level testing harder and prevents a single context from carrying `tipsDir`, `indexPath`, `embedder`, or service implementations.
+
+### 4. Additional architectural debt worth tracking
+
+- `src/cli.js` mixes command definition, formatting, path resolution, and execution wiring in one module.
+- `src/extract.js`, `src/contrastive.js`, and `src/seed.js` call `saveManyTips()` / `loadIndex()` without a shared runtime context, so storage concerns are scattered.
+- `src/seed.js` independently updates the index instead of delegating to store-layer save/reindex primitives.
+- `src/store.js` still uses environment-derived model defaults internally, which keeps storage logic partially coupled to process state.
+- Planned but not implemented: proactive tip seeding from skill metadata, already hinted by README issue references and explicitly requested here.
+
+# Plan
+
+Review the path and command wiring first, then drive the refactor through failing tests that remove cwd/env coupling and replace it with an explicit runtime context. The implementation should keep current behavior intact while making storage paths and embedders injectable across the full CLI surface.
+
+## Scope
+- In:
+- Dynamic or injectable path resolution for tips and index files
+- Consistent runtime context / DI through CLI commands and storage entry points
+- Test refactor away from `process.chdir()` and fragile embedders
+- Architecture findings and follow-up issue filing
+- Out:
+- Proactive skill-metadata seeding implementation
+- Large command-module decomposition beyond what is needed for DI consistency
+
+## Action items
+[ ] Add failing tests that prove path defaults break when cwd changes after module import and that CLI commands should honor injected paths without `process.chdir()`.
+[ ] Introduce a small runtime context helper that carries `tipsDir`, `indexPath`, `embedder`, and command implementation overrides through `createProgram()`.
+[ ] Refactor store/retrieve/seed entry points to resolve paths from explicit options or the shared context instead of cached module-level defaults.
+[ ] Update CLI command actions to use the same context for `add`, `extract`, `query`, `inject`, `list`, `consolidate`, `feedback`, `import`, `reindex`, `seed`, `contrast`, and `health`.
+[ ] Replace test embedders with a shared 16+ dimensional hash-spread fake and migrate CLI tests to per-test temp paths instead of `process.chdir()`.
+[ ] Run `node --test test/*.test.js` and `eslint src/ test/ bin/`, then inspect the diff for any behavior or API regressions before committing.
+[ ] File GitHub issues for proactive skill-metadata seeding and any remaining architectural debt that should not be addressed in this refactor.
+
+## Open questions
+- Should the runtime context remain an internal CLI-only concept, or should it become a first-class public API for library consumers later?
+- Should `seedBaseTips()` eventually reuse `saveTip()` / `saveManyTips()` to centralize index updates, or stay optimized for bootstrap copy semantics?
+- Should model selection also move into the runtime context in a follow-up, to fully decouple storage/retrieval from process environment?

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,6 +56,8 @@ async function promptForAddFields({
 async function addTipFromOptions(options, {
   saveTipImpl = saveTip,
   normalizeTipCandidateImpl = normalizeTipCandidate,
+  tipsDir = getTipsDir(),
+  indexPath = getIndexPath(),
   embedder,
   promptForFields = promptForAddFields,
   yaml = YAML
@@ -111,23 +113,44 @@ async function addTipFromOptions(options, {
     return { tip, saved: false, dryRun: true };
   }
 
-  const result = await saveTipImpl(tip, { embedder, tipsDir: getTipsDir(), indexPath: getIndexPath() });
+  const result = await saveTipImpl(tip, { embedder, tipsDir, indexPath });
   if (result.skipped) {
     console.log(chalk.yellow(`Skipped ${tip.id}: ${result.reason}`));
     return { ...result, saved: false, dryRun: false };
   }
 
-  console.log(chalk.green(`Saved ${tip.id} to ${getTipsDir()}`));
+  console.log(chalk.green(`Saved ${tip.id} to ${tipsDir}`));
   return { ...result, saved: true, dryRun: false };
 }
 
 export function createProgram(deps = {}) {
   const {
     addTip = addTipFromOptions,
+    extractTipsFromInputImpl = extractTipsFromInput,
+    analyzeTrajectoryIntelligenceImpl = analyzeTrajectoryIntelligence,
+    batchContrastiveAnalysisImpl = batchContrastiveAnalysis,
+    injectTipsImpl = injectTips,
+    queryTipsImpl = queryTips,
+    consolidateTipsImpl = consolidateTips,
+    recordFeedbackImpl = recordFeedback,
+    reindexAllTipsImpl = reindexAllTips,
+    importTipsFromInputsImpl = importTipsFromInputs,
+    loadAllTipsImpl = loadAllTips,
+    seedBaseTipsImpl,
     embedder,
     promptForFields,
-    yaml
+    yaml,
+    runtimeContext = {}
   } = deps;
+
+  function resolveContext() {
+    return {
+      tipsDir: runtimeContext.tipsDir ?? getTipsDir(),
+      indexPath: runtimeContext.indexPath ?? getIndexPath(),
+      embedder: runtimeContext.embedder ?? embedder
+    };
+  }
+
   const program = new Command();
   program
     .name('tips')
@@ -145,14 +168,19 @@ export function createProgram(deps = {}) {
     .option('--tags <tags>', 'comma-separated tags')
     .option('--source-trajectory <id>', 'source trajectory id')
     .option('--dry-run', 'print YAML without writing')
-    .action(async (options, command) => addTip({
-      ...options,
-      getOptionValueSource: (name) => command.getOptionValueSource(name)
-    }, {
-      embedder,
-      promptForFields,
-      yaml
-    }));
+    .action(async (options, command) => {
+      const context = resolveContext();
+      return addTip({
+        ...options,
+        getOptionValueSource: (name) => command.getOptionValueSource(name)
+      }, {
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder,
+        promptForFields,
+        yaml
+      });
+    });
 
   program
     .command('extract')
@@ -164,11 +192,15 @@ export function createProgram(deps = {}) {
     .option('--no-analyze', 'skip Phase 1 trajectory analysis (faster, lower quality)')
     .option('--verbose', 'show full analysis output')
     .action(async (input, options) => {
-      const result = await extractTipsFromInput(input, {
+      const context = resolveContext();
+      const result = await extractTipsFromInputImpl(input, {
         section: options.section,
         dryRun: options.dryRun,
         domain: options.domain,
-        analyze: options.analyze !== false
+        analyze: options.analyze !== false,
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
 
       console.log(chalk.green(`Outcome: ${result.trajectory_outcome}`));
@@ -233,7 +265,7 @@ export function createProgram(deps = {}) {
       }
 
       console.log(chalk.dim('Running Phase 1 trajectory analysis...'));
-      const analysis = await analyzeTrajectoryIntelligence(text, { domain: options.domain });
+      const analysis = await analyzeTrajectoryIntelligenceImpl(text, { domain: options.domain });
 
       if (options.json) {
         console.log(JSON.stringify(analysis, null, 2));
@@ -298,11 +330,15 @@ export function createProgram(deps = {}) {
     .option('--top <n>', 'result limit', '5')
     .option('--json', 'output JSON')
     .action(async (description, options) => {
-      const result = await queryTips(description, {
+      const context = resolveContext();
+      const result = await queryTipsImpl(description, {
         domain: options.domain,
         category: options.category,
         priority: options.priority,
-        top: Number(options.top || 5)
+        top: Number(options.top || 5),
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
 
       printWarnings(result.warnings);
@@ -327,10 +363,15 @@ export function createProgram(deps = {}) {
     .option('--focus <category>', 'focus category filter')
     .option('--domain <domain>', 'domain filter')
     .action(async (description, options) => {
-      const result = await injectTips(description, {
+      const context = resolveContext();
+      const result = await injectTipsImpl(description, {
         focus: options.focus,
         maxTokens: Number(options.maxTokens || 2000),
-        domain: options.domain
+        domain: options.domain,
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder,
+        queryTipsImpl
       });
       printWarnings(result.warnings);
       console.log(result.prompt);
@@ -345,8 +386,8 @@ export function createProgram(deps = {}) {
     .option('--since <date>', 'ISO date lower bound')
     .option('--stats', 'show stats summary')
     .action(async (options) => {
-      const tipsDir = getTipsDir();
-      const { tips, warnings } = await loadAllTips(tipsDir);
+      const context = resolveContext();
+      const { tips, warnings } = await loadAllTipsImpl(context.tipsDir);
       printWarnings(warnings);
 
       const priorities = normalizeListOption(options.priority);
@@ -383,9 +424,13 @@ export function createProgram(deps = {}) {
     .option('--dry-run', 'preview merges')
     .option('--threshold <n>', 'similarity threshold', '0.85')
     .action(async (options) => {
-      const result = await consolidateTips({
+      const context = resolveContext();
+      const result = await consolidateTipsImpl({
         dryRun: options.dryRun,
-        threshold: Number(options.threshold || 0.85)
+        threshold: Number(options.threshold || 0.85),
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
       printWarnings(result.warnings);
       console.log(JSON.stringify(result, null, 2));
@@ -397,7 +442,8 @@ export function createProgram(deps = {}) {
     .argument('<tip-id>', 'tip id')
     .argument('<outcome>', 'success|failure|irrelevant')
     .action(async (tipId, outcome) => {
-      const result = await recordFeedback(tipId, outcome);
+      const context = resolveContext();
+      const result = await recordFeedbackImpl(tipId, outcome, { tipsDir: context.tipsDir });
       console.log(JSON.stringify({
         id: result.id,
         effectiveness: result.effectiveness,
@@ -430,10 +476,14 @@ export function createProgram(deps = {}) {
         throw new Error('No valid input files found. If using glob patterns, let your shell expand them.');
       }
 
-      const results = await importTipsFromInputs(existing, {
+      const context = resolveContext();
+      const results = await importTipsFromInputsImpl(existing, {
         section: options.section,
         domain: options.domain,
-        dryRun: options.dryRun
+        dryRun: options.dryRun,
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
 
       const summary = {
@@ -448,7 +498,12 @@ export function createProgram(deps = {}) {
     .command('reindex')
     .description('Rebuild embeddings index from tip YAML files')
     .action(async () => {
-      const result = await reindexAllTips();
+      const context = resolveContext();
+      const result = await reindexAllTipsImpl({
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
+      });
       printWarnings(result.warnings);
       console.log(chalk.green(`Reindexed ${result.count} tip(s)`));
     });
@@ -460,9 +515,14 @@ export function createProgram(deps = {}) {
     .option('--skip-embeddings', 'copy YAMLs without generating embeddings')
     .action(async (options) => {
       const { seedBaseTips } = await import('./seed.js');
-      const result = await seedBaseTips({
+      const context = resolveContext();
+      const activeSeedBaseTips = seedBaseTipsImpl || seedBaseTips;
+      const result = await activeSeedBaseTips({
         baseDir: options.baseDir,
-        skipEmbeddings: options.skipEmbeddings
+        skipEmbeddings: options.skipEmbeddings,
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
       console.log(chalk.green(`Seeded ${result.count} base tip(s)`));
       if (result.skipped > 0) {
@@ -495,9 +555,13 @@ export function createProgram(deps = {}) {
       }
 
       console.log(chalk.dim(`Analyzing ${trajectories.length} trajectories...`));
-      const results = await batchContrastiveAnalysis(trajectories, {
+      const context = resolveContext();
+      const results = await batchContrastiveAnalysisImpl(trajectories, {
         domain: options.domain,
-        dryRun: options.dryRun
+        dryRun: options.dryRun,
+        tipsDir: context.tipsDir,
+        indexPath: context.indexPath,
+        embedder: context.embedder
       });
 
       if (options.json) {
@@ -535,8 +599,8 @@ export function createProgram(deps = {}) {
     .description('Show tip effectiveness stats, identify stale/failing tips')
     .option('--json', 'output JSON')
     .action(async (options) => {
-      const tipsDir = getTipsDir();
-      const { tips, warnings } = await loadAllTips(tipsDir);
+      const context = resolveContext();
+      const { tips, warnings } = await loadAllTipsImpl(context.tipsDir);
       printWarnings(warnings);
 
       const stats = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,8 +69,10 @@ async function addTipFromOptions(options, {
     'domain',
     'priority',
     'tags',
-    'sourceTrajectory',
-    'dryRun'
+    'steps',
+    'purpose',
+    'negativeExample',
+    'sourceTrajectory'
   ];
 
   const hasCliFlags = typeof options.getOptionValueSource === 'function'
@@ -92,13 +94,17 @@ async function addTipFromOptions(options, {
     throw new Error('Tip content and trigger are required.');
   }
 
+  const steps = normalizeListOption(options.steps);
   const tip = normalizeTipCandidateImpl({
     category: options.category,
     priority: options.priority,
     domain: options.domain,
     content,
     trigger,
-    tags: normalizeListOption(options.tags)
+    tags: normalizeListOption(options.tags),
+    steps: steps || [],
+    purpose: options.purpose || '',
+    negative_example: options.negativeExample || ''
   }, {
     domain: options.domain,
     sourceTrajectoryId: options.sourceTrajectory || 'manual',
@@ -166,6 +172,9 @@ export function createProgram(deps = {}) {
     .option('--domain <domain>', 'tip domain', 'general')
     .option('--priority <priority>', 'tip priority', 'medium')
     .option('--tags <tags>', 'comma-separated tags')
+    .option('--steps <steps>', 'comma-separated action steps')
+    .option('--purpose <purpose>', 'why this tip matters')
+    .option('--negative-example <example>', 'what NOT to do')
     .option('--source-trajectory <id>', 'source trajectory id')
     .option('--dry-run', 'print YAML without writing')
     .action(async (options, command) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,14 +1,22 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { createInterface as createReadlineInterface } from 'node:readline/promises';
 import { Command } from 'commander';
 import chalk from 'chalk';
+import YAML from 'yaml';
 import { extractTipsFromInput, importTipsFromInputs } from './extract.js';
 import { analyzeTrajectoryIntelligence } from './analyzer.js';
 import { batchContrastiveAnalysis } from './contrastive.js';
 import { injectTips } from './inject.js';
 import { queryTips } from './retrieve.js';
-import { consolidateTips, recordFeedback, reindexAllTips } from './store.js';
-import { getTipsDir, loadAllTips, normalizeListOption } from './utils.js';
+import {
+  consolidateTips,
+  normalizeTipCandidate,
+  recordFeedback,
+  reindexAllTips,
+  saveTip
+} from './store.js';
+import { getTipsDir, getIndexPath, loadAllTips, normalizeListOption } from './utils.js';
 
 function printWarnings(warnings = []) {
   for (const warning of warnings) {
@@ -30,12 +38,121 @@ function printTip(tip, score) {
   }
 }
 
-export function createProgram() {
+async function promptForAddFields({
+  input = process.stdin,
+  output = process.stdout,
+  createInterface = createReadlineInterface
+} = {}) {
+  const rl = createInterface({ input, output });
+  try {
+    const content = (await rl.question('Content: ')).trim();
+    const trigger = (await rl.question('Trigger: ')).trim();
+    return { content, trigger };
+  } finally {
+    rl.close();
+  }
+}
+
+async function addTipFromOptions(options, {
+  saveTipImpl = saveTip,
+  normalizeTipCandidateImpl = normalizeTipCandidate,
+  embedder,
+  promptForFields = promptForAddFields,
+  yaml = YAML
+} = {}) {
+  const trackedOptions = [
+    'content',
+    'trigger',
+    'category',
+    'domain',
+    'priority',
+    'tags',
+    'sourceTrajectory',
+    'dryRun'
+  ];
+
+  const hasCliFlags = typeof options.getOptionValueSource === 'function'
+    ? trackedOptions.some((name) => options.getOptionValueSource(name) === 'cli')
+    : false;
+
+  let content = options.content;
+  let trigger = options.trigger;
+
+  if (!hasCliFlags) {
+    const prompted = await promptForFields();
+    content = prompted.content;
+    trigger = prompted.trigger;
+  } else if (!content || !trigger) {
+    throw new Error('Both --content and --trigger are required unless running with no flags.');
+  }
+
+  if (!content || !trigger) {
+    throw new Error('Tip content and trigger are required.');
+  }
+
+  const tip = normalizeTipCandidateImpl({
+    category: options.category,
+    priority: options.priority,
+    domain: options.domain,
+    content,
+    trigger,
+    tags: normalizeListOption(options.tags)
+  }, {
+    domain: options.domain,
+    sourceTrajectoryId: options.sourceTrajectory || 'manual',
+    sourceOutcome: 'irrelevant',
+    sourceDescription: options.sourceTrajectory
+      ? `Added manually via CLI from trajectory ${options.sourceTrajectory}`
+      : 'Added manually via CLI'
+  });
+
+  if (options.dryRun) {
+    console.log(yaml.stringify(tip, { indent: 2 }).trimEnd());
+    return { tip, saved: false, dryRun: true };
+  }
+
+  const result = await saveTipImpl(tip, { embedder, tipsDir: getTipsDir(), indexPath: getIndexPath() });
+  if (result.skipped) {
+    console.log(chalk.yellow(`Skipped ${tip.id}: ${result.reason}`));
+    return { ...result, saved: false, dryRun: false };
+  }
+
+  console.log(chalk.green(`Saved ${tip.id} to ${getTipsDir()}`));
+  return { ...result, saved: true, dryRun: false };
+}
+
+export function createProgram(deps = {}) {
+  const {
+    addTip = addTipFromOptions,
+    embedder,
+    promptForFields,
+    yaml
+  } = deps;
   const program = new Command();
   program
     .name('tips')
     .description('Trajectory-informed memory generation for self-improving agent systems')
     .version('0.1.0');
+
+  program
+    .command('add')
+    .description('Add a single tip manually')
+    .option('--content <content>', 'what to do')
+    .option('--trigger <trigger>', 'when this applies')
+    .option('--category <category>', 'tip category', 'strategy')
+    .option('--domain <domain>', 'tip domain', 'general')
+    .option('--priority <priority>', 'tip priority', 'medium')
+    .option('--tags <tags>', 'comma-separated tags')
+    .option('--source-trajectory <id>', 'source trajectory id')
+    .option('--dry-run', 'print YAML without writing')
+    .action(async (options, command) => addTip({
+      ...options,
+      getOptionValueSource: (name) => command.getOptionValueSource(name)
+    }, {
+      embedder,
+      promptForFields,
+      yaml
+    }));
 
   program
     .command('extract')

--- a/src/contrastive.js
+++ b/src/contrastive.js
@@ -145,7 +145,10 @@ function formatAnalysisSummary(analysis, label) {
 async function batchContrastiveAnalysis(trajectories, {
   client,
   domain = 'general',
-  dryRun = false
+  dryRun = false,
+  tipsDir,
+  indexPath,
+  embedder
 } = {}) {
   const activeClient = client || createOpenAIClient();
   const results = [];
@@ -198,7 +201,7 @@ async function batchContrastiveAnalysis(trajectories, {
         }));
 
       if (!dryRun && tips.length > 0) {
-        await saveManyTips(tips);
+        await saveManyTips(tips, { tipsDir, indexPath, embedder });
       }
 
       results.push({
@@ -240,7 +243,7 @@ async function batchContrastiveAnalysis(trajectories, {
           }));
 
         if (!dryRun && tips.length > 0) {
-          await saveManyTips(tips);
+          await saveManyTips(tips, { tipsDir, indexPath, embedder });
         }
 
         results.push({

--- a/src/extract.js
+++ b/src/extract.js
@@ -72,7 +72,10 @@ export async function extractTipsFromInput(input, {
   dryRun = false,
   sourceDescription = '',
   client,
-  analyze = true
+  analyze = true,
+  tipsDir,
+  indexPath,
+  embedder
 } = {}) {
   const raw = await readTextInput(input);
   const sectioned = extractMarkdownSection(raw, section);
@@ -118,7 +121,7 @@ export async function extractTipsFromInput(input, {
     }));
 
   if (!dryRun) {
-    await saveManyTips(tips);
+    await saveManyTips(tips, { tipsDir, indexPath, embedder });
   }
 
   return {

--- a/src/inject.js
+++ b/src/inject.js
@@ -77,13 +77,20 @@ export async function injectTips(description, {
   focus,
   maxTokens = 2000,
   domain,
-  top = 5
+  top = 5,
+  tipsDir,
+  indexPath,
+  embedder,
+  queryTipsImpl = queryTips
 } = {}) {
-  const query = await queryTips(description, {
+  const query = await queryTipsImpl(description, {
     category: focus,
     domain,
     top,
-    includeNegative: true
+    includeNegative: true,
+    tipsDir,
+    indexPath,
+    embedder
   });
 
   const prompt = formatTipsForInjection(query.results, {

--- a/src/seed.js
+++ b/src/seed.js
@@ -11,6 +11,8 @@ const DEFAULT_BASE_DIR = path.resolve(__dirname, '..', 'examples');
 export async function seedBaseTips({
   baseDir = DEFAULT_BASE_DIR,
   tipsDir = getTipsDir(),
+  indexPath,
+  embedder = generateEmbedding,
   skipEmbeddings = false
 } = {}) {
   await ensureDir(tipsDir);
@@ -39,12 +41,12 @@ export async function seedBaseTips({
 
     if (!skipEmbeddings) {
       try {
-        const indexPath = path.resolve(process.cwd(), 'index.json');
-        const index = await loadIndex(indexPath);
+        const resolvedIndexPath = indexPath || path.resolve(process.cwd(), 'index.json');
+        const index = await loadIndex(resolvedIndexPath);
         const text = toEmbeddingText(tip);
-        const embedding = await generateEmbedding(text);
+        const embedding = await embedder(text);
         index.tips[tip.id] = { text, embedding, updated: tip.updated };
-        await saveIndex(index, indexPath);
+        await saveIndex(index, resolvedIndexPath);
       } catch (err) {
         // Embeddings optional during seed — can reindex later
         console.error(`Warning: embedding failed for ${tip.id}: ${err.message}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,7 @@ export function getTipsDir() {
 }
 
 export function getIndexPath() {
-  return DEFAULT_INDEX_PATH;
+  return path.resolve(process.cwd(), 'index.json');
 }
 
 export async function ensureDir(dirPath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,19 +2,13 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import YAML from 'yaml';
 
-export const DEFAULT_TIPS_DIR = process.env.TIPS_DIR
-  ? path.resolve(process.env.TIPS_DIR)
-  : path.resolve(process.cwd(), 'tips');
-
-export const DEFAULT_INDEX_PATH = path.resolve(process.cwd(), 'index.json');
-
 export const CATEGORY_VALUES = ['strategy', 'recovery', 'optimization'];
 export const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 
 export function getTipsDir() {
   return process.env.TIPS_DIR
     ? path.resolve(process.env.TIPS_DIR)
-    : DEFAULT_TIPS_DIR;
+    : path.resolve(process.cwd(), 'tips');
 }
 
 export function getIndexPath() {

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -5,38 +5,18 @@ import os from 'node:os';
 import path from 'node:path';
 import { createProgram } from '../src/cli.js';
 import { loadIndex } from '../src/store.js';
-import { readTipYaml, getIndexPath } from '../src/utils.js';
+import { readTipYaml } from '../src/utils.js';
+import { fakeEmbedder } from './helpers.js';
 
-function fakeEmbedder(text) {
-  // Produce distinct vectors for different texts using a simple hash spread
-  const dims = 16;
-  const vec = new Array(dims).fill(0);
-  for (let i = 0; i < text.length; i++) {
-    vec[(i * 7 + text.charCodeAt(i)) % dims] += text.charCodeAt(i) * (i + 1);
-  }
-  // Normalize
-  const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
-  return Promise.resolve(vec.map(v => v / mag));
-}
-
-async function withTempCliEnv(fn) {
-  const prevCwd = process.cwd();
-  const prevTipsDir = process.env.TIPS_DIR;
+async function withTempCliContext(fn) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tips-add-'));
   const tipsDir = path.join(dir, 'tips');
-
-  process.chdir(dir);
-  process.env.TIPS_DIR = tipsDir;
+  const indexPath = path.join(dir, 'index.json');
 
   try {
-    await fn({ dir, tipsDir });
+    await fn({ dir, tipsDir, indexPath });
   } finally {
-    process.chdir(prevCwd);
-    if (prevTipsDir === undefined) {
-      delete process.env.TIPS_DIR;
-    } else {
-      process.env.TIPS_DIR = prevTipsDir;
-    }
+    await fs.rm(dir, { recursive: true, force: true });
   }
 }
 
@@ -57,8 +37,10 @@ async function captureLogs(fn) {
 }
 
 test('tips add with all flags writes yaml and updates index', async () => {
-  await withTempCliEnv(async ({ _dir, tipsDir }) => {
-    const program = createProgram({ embedder: fakeEmbedder });
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder }
+    });
 
     await program.parseAsync([
       'add',
@@ -84,14 +66,16 @@ test('tips add with all flags writes yaml and updates index', async () => {
     assert.deepEqual(tip.tags, ['workers', 'locks', 'recovery']);
     assert.equal(tip.source.trajectory_id, 'traj-123');
 
-    const index = await loadIndex(getIndexPath());
+    const index = await loadIndex(indexPath);
     assert.ok(index.tips[tip.id]);
   });
 });
 
 test('tips add with only required flags applies defaults', async () => {
-  await withTempCliEnv(async ({ tipsDir }) => {
-    const program = createProgram({ embedder: fakeEmbedder });
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder }
+    });
 
     await program.parseAsync([
       'add',
@@ -112,8 +96,10 @@ test('tips add with only required flags applies defaults', async () => {
 });
 
 test('tips add dry run prints yaml without writing files', async () => {
-  await withTempCliEnv(async ({ _dir, tipsDir }) => {
-    const program = createProgram({ embedder: fakeEmbedder });
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder }
+    });
 
     const output = await captureLogs(async () => {
       await program.parseAsync([
@@ -133,8 +119,10 @@ test('tips add dry run prints yaml without writing files', async () => {
 });
 
 test('tips add errors when required flags are missing', async () => {
-  await withTempCliEnv(async () => {
-    const program = createProgram({ embedder: fakeEmbedder });
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder }
+    });
 
     await assert.rejects(
       program.parseAsync([

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createProgram } from '../src/cli.js';
+import { loadIndex } from '../src/store.js';
+import { readTipYaml, getIndexPath } from '../src/utils.js';
+
+function fakeEmbedder(text) {
+  // Produce distinct vectors for different texts using a simple hash spread
+  const dims = 16;
+  const vec = new Array(dims).fill(0);
+  for (let i = 0; i < text.length; i++) {
+    vec[(i * 7 + text.charCodeAt(i)) % dims] += text.charCodeAt(i) * (i + 1);
+  }
+  // Normalize
+  const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+  return Promise.resolve(vec.map(v => v / mag));
+}
+
+async function withTempCliEnv(fn) {
+  const prevCwd = process.cwd();
+  const prevTipsDir = process.env.TIPS_DIR;
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tips-add-'));
+  const tipsDir = path.join(dir, 'tips');
+
+  process.chdir(dir);
+  process.env.TIPS_DIR = tipsDir;
+
+  try {
+    await fn({ dir, tipsDir });
+  } finally {
+    process.chdir(prevCwd);
+    if (prevTipsDir === undefined) {
+      delete process.env.TIPS_DIR;
+    } else {
+      process.env.TIPS_DIR = prevTipsDir;
+    }
+  }
+}
+
+async function captureLogs(fn) {
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => {
+    logs.push(args.join(' '));
+  };
+
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+  }
+
+  return logs.join('\n');
+}
+
+test('tips add with all flags writes yaml and updates index', async () => {
+  await withTempCliEnv(async ({ _dir, tipsDir }) => {
+    const program = createProgram({ embedder: fakeEmbedder });
+
+    await program.parseAsync([
+      'add',
+      '--content', 'Restart the stuck worker after clearing the lock file',
+      '--trigger', 'Worker restarts fail because a stale lock remains',
+      '--category', 'recovery',
+      '--domain', 'infra',
+      '--priority', 'high',
+      '--tags', 'Workers,Locks,Recovery',
+      '--source-trajectory', 'traj-123'
+    ], { from: 'user' });
+
+    const files = await fs.readdir(tipsDir);
+    assert.equal(files.length, 1);
+
+    const tip = await readTipYaml(path.join(tipsDir, files[0]));
+    assert.match(tip.id, /^tip-\d{8}-[a-f0-9]{6}$/);
+    assert.equal(tip.category, 'recovery');
+    assert.equal(tip.domain, 'infra');
+    assert.equal(tip.priority, 'high');
+    assert.equal(tip.content, 'Restart the stuck worker after clearing the lock file');
+    assert.equal(tip.trigger, 'Worker restarts fail because a stale lock remains');
+    assert.deepEqual(tip.tags, ['workers', 'locks', 'recovery']);
+    assert.equal(tip.source.trajectory_id, 'traj-123');
+
+    const index = await loadIndex(getIndexPath());
+    assert.ok(index.tips[tip.id]);
+  });
+});
+
+test('tips add with only required flags applies defaults', async () => {
+  await withTempCliEnv(async ({ tipsDir }) => {
+    const program = createProgram({ embedder: fakeEmbedder });
+
+    await program.parseAsync([
+      'add',
+      '--content', 'Check the process table before retrying deploy',
+      '--trigger', 'A deploy appears hung'
+    ], { from: 'user' });
+
+    const files = await fs.readdir(tipsDir);
+    assert.equal(files.length, 1);
+
+    const tip = await readTipYaml(path.join(tipsDir, files[0]));
+    assert.equal(tip.category, 'strategy');
+    assert.equal(tip.domain, 'general');
+    assert.equal(tip.priority, 'medium');
+    assert.deepEqual(tip.tags, []);
+    assert.equal(tip.source.trajectory_id, 'manual');
+  });
+});
+
+test('tips add dry run prints yaml without writing files', async () => {
+  await withTempCliEnv(async ({ _dir, tipsDir }) => {
+    const program = createProgram({ embedder: fakeEmbedder });
+
+    const output = await captureLogs(async () => {
+      await program.parseAsync([
+        'add',
+        '--content', 'Tail the service logs before restarting',
+        '--trigger', 'The service crashes immediately after boot',
+        '--dry-run'
+      ], { from: 'user' });
+    });
+
+    assert.match(output, /id: tip-\d{8}-[a-f0-9]{6}/);
+    assert.match(output, /content: Tail the service logs before restarting/);
+    assert.match(output, /trigger: The service crashes immediately after boot/);
+
+    await assert.rejects(fs.access(tipsDir));
+  });
+});
+
+test('tips add errors when required flags are missing', async () => {
+  await withTempCliEnv(async () => {
+    const program = createProgram({ embedder: fakeEmbedder });
+
+    await assert.rejects(
+      program.parseAsync([
+        'add',
+        '--content', 'Only content is provided'
+      ], { from: 'user' }),
+      /Both --content and --trigger are required unless running with no flags\./
+    );
+  });
+});

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -118,6 +118,79 @@ test('tips add dry run prints yaml without writing files', async () => {
   });
 });
 
+test('tips add interactive mode uses promptForFields when no CLI flags given', async () => {
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const stubbedPrompt = async () => ({
+      content: 'Always check disk space before large imports',
+      trigger: 'Import job fails silently with no error'
+    });
+
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder },
+      promptForFields: stubbedPrompt
+    });
+
+    await program.parseAsync(['add'], { from: 'user' });
+
+    const files = await fs.readdir(tipsDir);
+    assert.equal(files.length, 1);
+
+    const tip = await readTipYaml(path.join(tipsDir, files[0]));
+    assert.equal(tip.content, 'Always check disk space before large imports');
+    assert.equal(tip.trigger, 'Import job fails silently with no error');
+    assert.equal(tip.category, 'strategy');
+    assert.equal(tip.source.trajectory_id, 'manual');
+  });
+});
+
+test('tips add interactive mode dry-run prints yaml without saving', async () => {
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const stubbedPrompt = async () => ({
+      content: 'Flush DNS cache after changing nameservers',
+      trigger: 'DNS changes not propagating locally'
+    });
+
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder },
+      promptForFields: stubbedPrompt
+    });
+
+    const output = await captureLogs(async () => {
+      await program.parseAsync(['add', '--dry-run'], { from: 'user' });
+    });
+
+    assert.match(output, /content: Flush DNS cache after changing nameservers/);
+    await assert.rejects(fs.access(tipsDir));
+  });
+});
+
+test('tips add with extended schema flags (steps, purpose, negative-example)', async () => {
+  await withTempCliContext(async ({ tipsDir, indexPath }) => {
+    const program = createProgram({
+      runtimeContext: { tipsDir, indexPath, embedder: fakeEmbedder }
+    });
+
+    await program.parseAsync([
+      'add',
+      '--content', 'Use connection pooling for database queries',
+      '--trigger', 'Database connections exhaust under load',
+      '--steps', 'Configure pool size,Set idle timeout,Monitor active connections',
+      '--purpose', 'Prevent connection exhaustion in production',
+      '--negative-example', 'Opening a new connection per request without pooling',
+      '--domain', 'coding',
+      '--priority', 'high'
+    ], { from: 'user' });
+
+    const files = await fs.readdir(tipsDir);
+    assert.equal(files.length, 1);
+
+    const tip = await readTipYaml(path.join(tipsDir, files[0]));
+    assert.deepEqual(tip.steps, ['Configure pool size', 'Set idle timeout', 'Monitor active connections']);
+    assert.equal(tip.purpose, 'Prevent connection exhaustion in production');
+    assert.equal(tip.negative_example, 'Opening a new connection per request without pooling');
+  });
+});
+
 test('tips add errors when required flags are missing', async () => {
   await withTempCliContext(async ({ tipsDir, indexPath }) => {
     const program = createProgram({

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,7 +5,7 @@ import { createProgram } from '../src/cli.js';
 test('CLI registers expected commands', () => {
   const program = createProgram();
   const names = program.commands.map((c) => c.name());
-  for (const required of ['extract', 'query', 'inject', 'list', 'consolidate', 'feedback', 'import', 'reindex']) {
+  for (const required of ['add', 'extract', 'query', 'inject', 'list', 'consolidate', 'feedback', 'import', 'reindex']) {
     assert.ok(names.includes(required), `missing command ${required}`);
   }
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { createProgram } from '../src/cli.js';
+import { fakeEmbedder } from './helpers.js';
 
 test('CLI registers expected commands', () => {
   const program = createProgram();
@@ -20,4 +24,28 @@ test('query command parses arguments', async () => {
 
   await program.parseAsync(['query', 'deploy'], { from: 'user' });
   assert.equal(called, true);
+});
+
+test('query command uses injected implementation and runtime paths', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tips-cli-query-'));
+  const calls = [];
+  const program = createProgram({
+    runtimeContext: {
+      tipsDir: path.join(dir, 'tips'),
+      indexPath: path.join(dir, 'index.json'),
+      embedder: fakeEmbedder
+    },
+    queryTipsImpl: async (description, options) => {
+      calls.push({ description, options });
+      return { method: 'semantic', warnings: [], results: [] };
+    }
+  });
+
+  await program.parseAsync(['query', 'deploy issue'], { from: 'user' });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].description, 'deploy issue');
+  assert.equal(calls[0].options.tipsDir, path.join(dir, 'tips'));
+  assert.equal(calls[0].options.indexPath, path.join(dir, 'index.json'));
+  assert.equal(calls[0].options.embedder, fakeEmbedder);
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,13 @@
+export function fakeEmbedder(text) {
+  const dims = 16;
+  const vec = new Array(dims).fill(0);
+
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    vec[(i * 7 + code) % dims] += code * (i + 1);
+    vec[(i * 11 + code) % dims] += code * 0.5;
+  }
+
+  const mag = Math.sqrt(vec.reduce((sum, value) => sum + (value * value), 0)) || 1;
+  return Promise.resolve(vec.map((value) => value / mag));
+}

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -10,11 +10,7 @@ import {
   findDuplicates,
   normalizeTipCandidate
 } from '../src/store.js';
-
-function fakeEmbedder(text) {
-  const codePointSum = [...text].reduce((sum, char) => sum + char.charCodeAt(0), 0);
-  return Promise.resolve([text.length, codePointSum, 1]);
-}
+import { fakeEmbedder } from './helpers.js';
 
 function mkTip(id, content) {
   return normalizeTipCandidate({

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   cosineSimilarity,
+  getTipsDir,
   writeTipYaml,
   readTipYaml,
   loadAllTips
@@ -37,4 +38,24 @@ test('YAML tip serialization/deserialization round trip', async () => {
   const loaded = await loadAllTips(dir);
   assert.equal(loaded.tips.length, 1);
   assert.equal(loaded.tips[0].id, 'tip-1');
+});
+
+test('getTipsDir resolves from current cwd at call time when TIPS_DIR is unset', async () => {
+  const previousCwd = process.cwd();
+  const previousTipsDir = process.env.TIPS_DIR;
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tips-utils-cwd-'));
+
+  delete process.env.TIPS_DIR;
+  process.chdir(dir);
+
+  try {
+    assert.equal(getTipsDir(), path.join(dir, 'tips'));
+  } finally {
+    process.chdir(previousCwd);
+    if (previousTipsDir === undefined) {
+      delete process.env.TIPS_DIR;
+    } else {
+      process.env.TIPS_DIR = previousTipsDir;
+    }
+  }
 });


### PR DESCRIPTION
Adds tips add CLI + architecture fixes for path resolution and DI. 18/18 tests passing, lint clean. All 4 Copilot review comments addressed — see commit 9875bb4.